### PR TITLE
Connect summary agent to hybrid retrieval

### DIFF
--- a/main_agent.py
+++ b/main_agent.py
@@ -1,54 +1,30 @@
-# from chains.qa_chain import run_qa_chain
-# from ragas_evaluations.ragas_eval_summarize import get_summary
-# from ragas_evaluations.ragas_eval_qna import make_qna_ragas_evaluation
-# from ragas_evaluations.ragas_eval_summarize import make_summarize_evaluation
 import os
 import gradio as gr
 
 from helpers.qa_rag import ask
-
-# from agents.summary_agent import summarize_rag
-# from eval.ragas_eval import evaluate_with_ragas
+from agents.summary_agent import summarize_rag
+from ragas_evaluations.ragas_eval_summarize import evaluate_summary
 
 def ask_qa_rag(prompt: str):
     answer = ask(prompt)
     return answer
 
 
-_last_response = {"question": None, "answer": None, "contexts": None}
+_last_response = {"question": None, "answer": None, "contexts": None, "metrics": None}
 
 def router_agent(operation: str, prompt: str):
     if operation == "qna":
         ans = ask_qa_rag(prompt)
-        _last_response.update({"question": prompt, "answer": ans, "contexts": []})
+        _last_response.update({"question": prompt, "answer": ans, "contexts": [], "metrics": None})
         return ans
     elif operation == "summarize":
-        # out = summarize_rag(prompt, top_k=int(os.getenv("TOP_K", "5")))
-        # _last_response.update({"question": prompt, "answer": out["answer"], "contexts": out["contexts"]})
-        # return out["answer"]
-        return "בקרוב בקולנוע"
+        out = summarize_rag(prompt, top_k=int(os.getenv("TOP_K", "5")))
+        metrics = evaluate_summary(prompt, out["answer"], out["contexts"])
+        _last_response.update({"question": prompt, "answer": out["answer"], "contexts": out["contexts"], "metrics": metrics})
+        return out["answer"] + f"\n\n**RAGAS**\nFaithfulness: {metrics['faithfulness']:.3f}"
     else:
         return "Unknown operation selected."
     
-# def run_ragas(_):
-#     if not _last_response["answer"] or _last_response["question"] is None:
-#         return "No previous answer to evaluate. Ask something first."
-#     metrics = evaluate_with_ragas(
-#         question=_last_response["question"],
-#         answer=_last_response["answer"],
-#         contexts=_last_response["contexts"] or [],
-#         ground_truth=None,  # optionally pass a reference summary here
-#     )
-#     if "error" in metrics:
-#         return f"RAGAS error: {metrics['error']}"
-#     # pretty print
-#     return (
-#         f"**RAGAS Metrics**\n\n"
-#         f"- Faithfulness: {metrics.get('faithfulness', 'n/a'):.3f}\n"
-#         f"- Answer Relevancy: {metrics.get('answer_relevancy', 'n/a'):.3f}\n"
-#         f"- Context Precision: {metrics.get('context_precision', 'n/a'):.3f}\n"
-#         f"- Context Recall: {metrics.get('context_recall', 'n/a'):.3f}\n"
-#     )
 
 
 def main():
@@ -63,9 +39,7 @@ def main():
         """
         ) as demo:
         gr.Markdown("# 🤖 Songbook RAG")
-        gr.Markdown("Ask about the songbook • Choose QnA or Summarize • (Optional) evaluate with RAGAS")
-        # gr.Markdown("# 🤖 Songbook RAG")
-        # gr.Markdown("Enter a question about the songbook.")
+        gr.Markdown("Ask about the songbook • Choose QnA or Summarize")
 
         with gr.Row():
             operation = gr.Dropdown(label="Operation", choices=["qna", "summarize"], value="qna", scale=0)
@@ -77,8 +51,7 @@ def main():
             clear = gr.Button("Clear", elem_id="clear_btn")
             
         output = gr.Markdown()
-        
-        # submit.click(ask_qa_rag, inputs=prompt, outputs=output)
+
         submit.click(router_agent, inputs=[operation, prompt], outputs=output)
         clear.click(fn=lambda: ("", ""), inputs=None, outputs=[prompt, output])
 

--- a/ragas_evaluations/ragas_eval_summarize.py
+++ b/ragas_evaluations/ragas_eval_summarize.py
@@ -1,130 +1,46 @@
+"""Utility to evaluate summaries using RAGAS metrics."""
 
-# This is an old script that we have to change!
-# python ragas_eval_summarize.py
+from __future__ import annotations
 
+from typing import List, Dict
 
-from ragas.metrics import answer_correctness
-from ragas.evaluation import evaluate
-import sys
-import os
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
-from helpers.config import SUMMARY_RESULT_PATH, SUMMARY_GROUND_TRUTH_PATH, RAGAS_SUMMARIZE_EVALUATION_PATH, FILE_PATH, \
-    OPENAI_API_KEY
-from langchain_openai import ChatOpenAI
 from datasets import Dataset
+from ragas.evaluation import evaluate
+from ragas.metrics import faithfulness
+from langchain_openai import ChatOpenAI
+
+from helpers.config import OPENAI_API_KEY
 
 
-def get_summary():
-    return open(SUMMARY_RESULT_PATH, 'r', encoding='utf-8').read()
+def evaluate_summary(question: str, answer: str, contexts: List[str]) -> Dict[str, float]:
+    """Evaluate a generated summary against its source context.
 
+    Parameters
+    ----------
+    question: str
+        The original user prompt.
+    answer: str
+        The summary generated for the prompt.
+    contexts: List[str]
+        Context passages used to create the summary.
 
-def truncate_text(text, max_chars=1500):
-    """Truncate text to prevent token overflow"""
-    if len(text) <= max_chars:
-        return text
-    return text[:max_chars] + "..."
+    Returns
+    -------
+    Dict[str, float]
+        Mapping of metric names to their scores.
+    """
 
+    llm = ChatOpenAI(temperature=0, api_key=OPENAI_API_KEY)
 
-def smart_truncate_summary(text, max_chars=3000):
-    """Smart truncation that tries to preserve complete sections"""
-    if len(text) <= max_chars:
-        return text
-    
-    # Try to find a good breaking point near the limit
-    # Look for section breaks or paragraph breaks
-    truncated = text[:max_chars]
-    
-    # Try to break at a section header or paragraph
-    last_section = truncated.rfind('\n\n')
-    if last_section > max_chars * 0.7:  # If we can find a good break point in the last 30%
-        return text[:last_section] + "..."
-    
-    # Try to break at a single newline
-    last_newline = truncated.rfind('\n')
-    if last_newline > max_chars * 0.8:
-        return text[:last_newline] + "..."
-    
-    return truncated + "..."
-
-
-def make_summarize_evaluation():
-    print("Making summarize evaluation...")
-    # Use a reasonable max_tokens value that works with the model
-    llm = ChatOpenAI(
-        temperature=0, 
-        api_key=OPENAI_API_KEY, 
-        max_tokens=4000,  # Increased to allow for longer evaluation
-        model="gpt-3.5-turbo-16k"  # Use 16k model for larger context
+    dataset = Dataset.from_dict(
+        {
+            "question": [question],
+            "answer": [answer],
+            "contexts": [contexts],
+        }
     )
 
-    question = "Summarize the document in the best way possible. Focus on creating a clear and structured summary"
-    
-    # Read and truncate all inputs to prevent token overflow
-    context = open(FILE_PATH, 'r', encoding='utf-8').read()
-    summary = get_summary()
-    ground_truth = open(SUMMARY_GROUND_TRUTH_PATH, 'r', encoding='utf-8').read()
+    results = evaluate(dataset, metrics=[faithfulness], llm=llm)
 
-    # Use much larger limits to preserve more content
-    context_truncated = truncate_text(context, 4000)  # Increased from 2000
-    summary_truncated = smart_truncate_summary(summary, 4000)  # Increased from 1000
-    ground_truth_truncated = smart_truncate_summary(ground_truth, 4000)  # Increased from 1000
+    return {"faithfulness": float(results["faithfulness"][0])}
 
-    print(f"Context length: {len(context_truncated)} chars")
-    print(f"Summary length: {len(summary_truncated)} chars")
-    print(f"Ground truth length: {len(ground_truth_truncated)} chars")
-
-    eval_dataset = Dataset.from_dict({
-        "question": [question],
-        "context": [context_truncated],
-        "answer": [summary_truncated],
-        "ground_truth": [ground_truth_truncated]
-    })
-
-    try:
-        print("Starting evaluation...")
-        results = evaluate(
-            eval_dataset,
-            metrics=[answer_correctness],
-            llm=llm
-        )
-
-        answer_correctness_score = results["answer_correctness"][0]
-        print("\n=== RAGAS Answer Correctness Score ===")
-        print(f"Answer Correctness: {answer_correctness_score:.4f}")
-
-        with open(RAGAS_SUMMARIZE_EVALUATION_PATH, "w", encoding="utf-8") as f:
-            f.write("=== RAGAS ANSWER CORRECTNESS EVALUATION FOR SUMMARY ===\n")
-            f.write(f"Answer Correctness Score: {answer_correctness_score:.4f}\n")
-            f.write(f"\nInput lengths:\n")
-            f.write(f"- Context: {len(context_truncated)} chars\n")
-            f.write(f"- Summary: {len(summary_truncated)} chars\n")
-            f.write(f"- Ground Truth: {len(ground_truth_truncated)} chars\n")
-            f.write("\n--- SUMMARY (truncated) ---\n")
-            f.write(summary_truncated)
-            f.write("\n\n--- GROUND TRUTH (truncated) ---\n")
-            f.write(ground_truth_truncated)
-            f.write("\n\n--- CONTEXT (truncated) ---\n")
-            f.write(context_truncated)
-
-    except Exception as e:
-        print(f"❌ Error evaluating answer correctness: {e}")
-        print(f"Error type: {type(e).__name__}")
-        
-        # Write error details to file for debugging
-        with open(RAGAS_SUMMARIZE_EVALUATION_PATH, "w", encoding="utf-8") as f:
-            f.write("=== RAGAS ANSWER CORRECTNESS EVALUATION FOR SUMMARY ===\n")
-            f.write(f"ERROR: {str(e)}\n")
-            f.write(f"Error type: {type(e).__name__}\n")
-            f.write(f"\nInput lengths:\n")
-            f.write(f"- Context: {len(context_truncated)} chars\n")
-            f.write(f"- Summary: {len(summary_truncated)} chars\n")
-            f.write(f"- Ground Truth: {len(ground_truth_truncated)} chars\n")
-            f.write("\n--- SUMMARY (truncated) ---\n")
-            f.write(summary_truncated)
-            f.write("\n\n--- GROUND TRUTH (truncated) ---\n")
-            f.write(ground_truth_truncated)
-            f.write("\n\n--- CONTEXT (truncated) ---\n")
-            f.write(context_truncated)
-
-# make_summarize_evaluation()


### PR DESCRIPTION
## Summary
- Replace vector store dependency in summary_agent with existing hybrid_search utility
- Wire summarize_rag into main_agent routing to enable summarization
- Add lightweight RAGAS evaluation for summaries and trigger it automatically after summarization

## Testing
- `python -m py_compile agents/summary_agent.py main_agent.py ragas_evaluations/ragas_eval_summarize.py`
- `python - <<'PY'
from main_agent import router_agent
try:
    print(router_agent('summarize', 'מה כתבתי על שלג?')[:200])
except Exception as e:
    print('ERROR:', type(e).__name__, e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ac75afaa788330a94f66e2a87c21d9