### PR TITLE
Validate chunk overlap and add unit tests

### DIFF
--- a/agents/utils.py
+++ b/agents/utils.py
@@ -1,12 +1,29 @@
 
 from typing import List
 
+
 def chunk_text(text: str, chunk_size: int = 1000, overlap: int = 150) -> List[str]:
+    """Split ``text`` into overlapping chunks.
+
+    Args:
+        text: The source text to split.
+        chunk_size: Maximum size of each chunk.
+        overlap: Number of characters to overlap between consecutive chunks.
+
+    Returns:
+        A list containing the text chunks.
+
+    Raises:
+        ValueError: If ``overlap`` is not smaller than ``chunk_size``.
+    """
+
+    if overlap >= chunk_size:
+        raise ValueError("overlap must be smaller than chunk_size")
+
     parts = []
     i = 0
+    step = chunk_size - overlap
     while i < len(text):
-        parts.append(text[i:i+chunk_size])
-        i += chunk_size - overlap
-        if i < 0:
-            break
+        parts.append(text[i:i + chunk_size])
+        i += step
     return parts

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from agents.utils import chunk_text
+
+def test_chunk_text_normal():
+    text = "abcdefghijklmnopqrstuvwxyz"
+    expected = [
+        "abcdefghij",
+        "ijklmnopqr",
+        "qrstuvwxyz",
+        "yz",
+    ]
+    assert chunk_text(text, chunk_size=10, overlap=2) == expected
+
+def test_chunk_text_invalid_overlap():
+    with pytest.raises(ValueError):
+        chunk_text("some text", chunk_size=10, overlap=10)


### PR DESCRIPTION
## Summary
- ensure `chunk_text` raises `ValueError` when overlap is not smaller than the chunk size
- simplify chunking loop by removing unreachable guard
- add tests for normal chunking and invalid overlap

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac761e25cc8330abacd06ec4b6e552