### PR TITLE
Remove top_k from summary agent

### DIFF
--- a/agents/summary_agent.py
+++ b/agents/summary_agent.py
@@ -5,8 +5,6 @@ import re
 from helpers.hybride_retreval import hybrid_search
 from core.llm import get_llm
 
-DEFAULT_TOP_K = 5
-
 SUMMARY_SYSTEM_PROMPT = """אתה מסייע סיכום קפדן עבור מערכת שאלות־תשובות של ספר שירים.
 - הפק סיכום נאמן ומתומצת העונה לבקשת המשתמש.
 - השתמש רק בהקשר שסופק; אל תמציא עובדות.
@@ -63,7 +61,7 @@ def _extract_song_names(question: str) -> List[str]:
             seen.append(n)
     return seen
 
-def summarize_rag(question: str, top_k: int = DEFAULT_TOP_K) -> dict:
+def summarize_rag(question: str) -> dict:
     """
     Returns a dict: { 'answer': str, 'contexts': List[str], 'raw_docs': List[Document-like] }
     """
@@ -72,7 +70,7 @@ def summarize_rag(question: str, top_k: int = DEFAULT_TOP_K) -> dict:
     docs: List[Any] = []
     if song_names:
         for name in song_names:
-            docs.extend(hybrid_search(question, k=top_k, song_name=name))
+            docs.extend(hybrid_search(question, song_name=name))
 
         # Deduplicate while preserving order
         seen_keys = set()
@@ -83,9 +81,9 @@ def summarize_rag(question: str, top_k: int = DEFAULT_TOP_K) -> dict:
             if key not in seen_keys:
                 seen_keys.add(key)
                 deduped.append(d)
-        docs = deduped[:top_k]
+        docs = deduped
     else:
-        docs = hybrid_search(question, k=top_k)
+        docs = hybrid_search(question)
 
     context_str = _format_docs(docs)
     llm = get_llm()

--- a/main_agent.py
+++ b/main_agent.py
@@ -1,4 +1,3 @@
-import os
 import gradio as gr
 
 from helpers.qa_rag import ask
@@ -18,7 +17,7 @@ def router_agent(operation: str, prompt: str):
         _last_response.update({"question": prompt, "answer": ans, "contexts": [], "metrics": None})
         return ans
     elif operation == "summarize":
-        out = summarize_rag(prompt, top_k=int(os.getenv("TOP_K", "5")))
+        out = summarize_rag(prompt)
         metrics = evaluate_summary(prompt, out["answer"], out["contexts"])
         _last_response.update({"question": prompt, "answer": out["answer"], "contexts": out["contexts"], "metrics": metrics})
         return out["answer"] + f"\n\n**RAGAS**\nFaithfulness: {metrics['faithfulness']:.3f}"

--- a/tests/test_summary_agent.py
+++ b/tests/test_summary_agent.py
@@ -29,7 +29,7 @@ def test_summarize_rag_filters_to_song(monkeypatch):
     monkeypatch.setattr("agents.summary_agent.hybrid_search", fake_hybrid_search)
     monkeypatch.setattr("agents.summary_agent.get_llm", lambda: DummyLLM())
 
-    result = summarize_rag('מה המסר בשיר "Imagine"?', top_k=3)
+    result = summarize_rag('מה המסר בשיר "Imagine"?')
 
     assert calls['song_name'] == "Imagine"
     assert all(doc.metadata["song_name"] == "Imagine" for doc in result["raw_docs"])


### PR DESCRIPTION
## Summary
- Drop configurable `top_k` from `summarize_rag` and rely on retriever defaults
- Adjust main agent to call summary without `TOP_K` environment variable
- Update tests accordingly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aee68026c48330af840627fdc4d857