### PR TITLE
Load July summary ground truths for RAGAS evaluation

### DIFF
--- a/ragas_evaluations/ragas_eval_summarize.py
+++ b/ragas_evaluations/ragas_eval_summarize.py
@@ -1,11 +1,51 @@
 """Utility to evaluate summaries using RAGAS metrics."""
 
-from typing import List, Dict
+from typing import Dict, List, Optional
+from difflib import get_close_matches
+import os
 
 from helpers.config import OPENAI_API_KEY
 
+# Path to summary ground-truth files
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SUMMARY_GT_DIR = os.path.join(BASE_DIR, "ground_truth", "summary_gt", "2021", "july")
 
-def evaluate_summary(question: str, answer: str, contexts: List[str]) -> Dict[str, float]:
+
+def load_summary_ground_truth(song_name: str) -> str:
+    """Load ground-truth summary text for a given song.
+
+    Parameters
+    ----------
+    song_name: str
+        The name of the song to search for.
+
+    Returns
+    -------
+    str
+        Contents of the matching ground-truth file.
+    """
+
+    files = os.listdir(SUMMARY_GT_DIR)
+    # Try direct substring match first for robustness with Hebrew names
+    direct = [f for f in files if song_name in f]
+    if direct:
+        filename = direct[0]
+    else:
+        match = get_close_matches(song_name, files, n=1, cutoff=0.5)
+        if not match:
+            raise FileNotFoundError(f"No ground truth summary found for '{song_name}'")
+        filename = match[0]
+    path = os.path.join(SUMMARY_GT_DIR, filename)
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read().strip()
+
+
+def evaluate_summary(
+    question: str,
+    answer: str,
+    contexts: List[str],
+    ground_truth: Optional[str] = None,
+) -> Dict[str, float]:
     """Evaluate a generated summary against its source context.
 
     Parameters
@@ -16,6 +56,8 @@ def evaluate_summary(question: str, answer: str, contexts: List[str]) -> Dict[st
         The summary generated for the prompt.
     contexts: List[str]
         Context passages used to create the summary.
+    ground_truth: Optional[str]
+        Reference summary text. When provided, answer relevancy is also scored.
 
     Returns
     -------
@@ -26,7 +68,7 @@ def evaluate_summary(question: str, answer: str, contexts: List[str]) -> Dict[st
     try:
         from datasets import Dataset
         from ragas.evaluation import evaluate
-        from ragas.metrics import faithfulness
+        from ragas.metrics import faithfulness, answer_relevancy
         from langchain_openai import ChatOpenAI
     except Exception as exc:
         raise ImportError(
@@ -35,15 +77,22 @@ def evaluate_summary(question: str, answer: str, contexts: List[str]) -> Dict[st
 
     llm = ChatOpenAI(temperature=0, api_key=OPENAI_API_KEY)
 
-    dataset = Dataset.from_dict(
-        {
-            "question": [question],
-            "answer": [answer],
-            "contexts": [contexts],
-        }
-    )
+    data = {
+        "question": [question],
+        "answer": [answer],
+        "contexts": [contexts],
+    }
+    metrics = [faithfulness]
+    if ground_truth is not None:
+        data["ground_truth"] = [ground_truth]
+        metrics.append(answer_relevancy)
 
-    results = evaluate(dataset, metrics=[faithfulness], llm=llm)
+    dataset = Dataset.from_dict(data)
 
-    return {"faithfulness": float(results["faithfulness"][0])}
+    results = evaluate(dataset, metrics=metrics, llm=llm)
+
+    scores = {"faithfulness": float(results["faithfulness"][0])}
+    if ground_truth is not None and "answer_relevancy" in results:
+        scores["answer_relevancy"] = float(results["answer_relevancy"][0])
+    return scores
 

--- a/tests/test_summary_ragas.py
+++ b/tests/test_summary_ragas.py
@@ -1,0 +1,11 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from ragas_evaluations.ragas_eval_summarize import load_summary_ground_truth
+
+
+def test_load_summary_ground_truth():
+    text = load_summary_ground_truth("איך לשכוח")
+    assert "Question 1" in text


### PR DESCRIPTION
## Summary
- extend RAGAS summary evaluation to score answer relevancy when a reference summary is provided
- load summary ground truth files from `ground_truth/summary_gt/2021/july`
- add tests validating ground truth loading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af046618208330b050ba90e09b56da