### PR TITLE
Handle missing ragas dependencies gracefully

### DIFF
--- a/main_agent.py
+++ b/main_agent.py
@@ -20,7 +20,11 @@ def router_agent(operation: str, prompt: str):
         out = summarize_rag(prompt)
         metrics = evaluate_summary(prompt, out["answer"], out["contexts"])
         _last_response.update({"question": prompt, "answer": out["answer"], "contexts": out["contexts"], "metrics": metrics})
-        return out["answer"] + f"\n\n**RAGAS**\nFaithfulness: {metrics['faithfulness']:.3f}"
+        if metrics is None:
+            metrics_text = "\n\n**RAGAS**\nEvaluation unavailable."
+        else:
+            metrics_text = f"\n\n**RAGAS**\nFaithfulness: {metrics['faithfulness']:.3f}"
+        return out["answer"] + metrics_text
     else:
         return "Unknown operation selected."
     

--- a/ragas_evaluations/ragas_eval_summarize.py
+++ b/ragas_evaluations/ragas_eval_summarize.py
@@ -45,7 +45,7 @@ def evaluate_summary(
     answer: str,
     contexts: List[str],
     ground_truth: Optional[str] = None,
-) -> Dict[str, float]:
+) -> Optional[Dict[str, float]]:
     """Evaluate a generated summary against its source context.
 
     Parameters
@@ -61,8 +61,9 @@ def evaluate_summary(
 
     Returns
     -------
-    Dict[str, float]
-        Mapping of metric names to their scores.
+    Optional[Dict[str, float]]
+        Mapping of metric names to their scores, or ``None`` if the evaluation
+        dependencies are unavailable.
     """
 
     try:
@@ -71,9 +72,13 @@ def evaluate_summary(
         from ragas.metrics import faithfulness, answer_relevancy
         from langchain_openai import ChatOpenAI
     except Exception as exc:
-        raise ImportError(
-            "ragas evaluation dependencies are missing or incompatible with this Python version"
-        ) from exc
+        # Optional evaluation: gracefully skip when ragas or its dependencies
+        # are not installed (e.g. on Python < 3.10 without ``eval_type_backport``)
+        print(
+            "RAGAS evaluation skipped: dependencies are missing or incompatible with this Python version",
+            exc,
+        )
+        return None
 
     llm = ChatOpenAI(temperature=0, api_key=OPENAI_API_KEY)
 


### PR DESCRIPTION
## Summary
- allow `evaluate_summary` to skip RAGAS metrics when dependencies aren't available
- avoid crashing in Gradio app and show message when evaluation is unavailable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af0863aff48330941b0480faffe787