### PR TITLE
Gracefully skip RAGAS eval on Python 3.9

### DIFF
--- a/eval/ragas_eval.py
+++ b/eval/ragas_eval.py
@@ -1,11 +1,15 @@
 
 from typing import List, Dict, Optional
+import sys
+
 
 def evaluate_with_ragas(question: str, answer: str, contexts: List[str], ground_truth: Optional[str] = None) -> Dict:
     """
     Runs a small RAGAS evaluation on a single (q, a, contexts[, ground_truth]) sample.
     Returns a dict of metrics.
     """
+    if sys.version_info < (3, 10):
+        return {"error": "RAGAS evaluation requires Python 3.10 or higher"}
     try:
         from ragas import evaluate
         from ragas.metrics import faithfulness, answer_relevancy, context_precision, context_recall

--- a/ragas_evaluations/ragas_eval_qna.py
+++ b/ragas_evaluations/ragas_eval_qna.py
@@ -108,13 +108,17 @@ def make_qna_ragas_evaluation(prompt: str):
     print(f"Contexts ({len(context)}):\n- " + "\n- ".join(c[:120] + "..." for c in context))
 
     try:
+        if sys.version_info < (3, 10):
+            raise RuntimeError("Python 3.10+ required for ragas evaluation")
         from datasets import Dataset
         from ragas.metrics import faithfulness, context_precision, context_recall
         from ragas.evaluation import evaluate
     except Exception as exc:
-        raise ImportError(
-            "ragas evaluation dependencies are missing or incompatible with this Python version"
-        ) from exc
+        print(
+            "RAGAS evaluation skipped: dependencies are missing or incompatible with this Python version",
+            exc,
+        )
+        return answer
 
     dataset = Dataset.from_dict({
         "question": [prompt],

--- a/ragas_evaluations/ragas_eval_summarize.py
+++ b/ragas_evaluations/ragas_eval_summarize.py
@@ -3,6 +3,7 @@
 from typing import Dict, List, Optional
 from difflib import get_close_matches
 import os
+import sys
 
 from helpers.config import OPENAI_API_KEY
 
@@ -66,6 +67,10 @@ def evaluate_summary(
         dependencies are unavailable.
     """
 
+    if sys.version_info < (3, 10):
+        print("RAGAS evaluation requires Python 3.10 or higher. Skipping.")
+        return None
+
     try:
         from datasets import Dataset
         from ragas.evaluation import evaluate
@@ -73,7 +78,7 @@ def evaluate_summary(
         from langchain_openai import ChatOpenAI
     except Exception as exc:
         # Optional evaluation: gracefully skip when ragas or its dependencies
-        # are not installed (e.g. on Python < 3.10 without ``eval_type_backport``)
+        # are not installed
         print(
             "RAGAS evaluation skipped: dependencies are missing or incompatible with this Python version",
             exc,


### PR DESCRIPTION
## Summary
- Ensure RAGAS evaluation utilities run under Python 3.9 by skipping imports when Python < 3.10
- Provide clearer messages when evaluation dependencies are unavailable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af0f5d90f48330aa0356c814b9f3da